### PR TITLE
remark-custom-blocks: add failing test case

### DIFF
--- a/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
+++ b/packages/remark-custom-blocks/__tests__/__snapshots__/index.js.snap
@@ -88,6 +88,14 @@ exports[`compile fixture to markdown 1`] = `
 "
 `;
 
+exports[`compile multiline block to markdown 1`] = `
+"[[information]]
+| content
+| > blockquote
+| simple paragraph
+"
+`;
+
 exports[`compile regression1 to markdown 1`] = `
 "content before
 
@@ -99,7 +107,7 @@ with content after
 `;
 
 exports[`compile titled block to markdown 1`] = `
-"[[details|my title]]
+"[[details | **my** title]]
 | content
 "
 `;

--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -260,11 +260,27 @@ test('compile regression1 to markdown', () => {
 
 test('compile titled block to markdown', () => {
   const {contents} = renderToMarkdown(dedent`
-    [[details| my title]]
+    [[details| **my** title]]
     | content
   `)
 
   expect(contents).toMatchSnapshot()
   const result = renderToMarkdown(contents)
   expect(result.contents).toBe(contents)
+})
+
+test('compile multiline block to markdown', () => {
+  const fixture = dedent`
+    [[information]]
+    | content
+    | > blockquote
+    |
+    | simple paragraph
+  `
+  const {contents} = renderToMarkdown(fixture)
+
+  expect(contents).toMatchSnapshot()
+  const result = renderToMarkdown(contents)
+  expect(result.contents).toBe(contents)
+  expect(render(result.contents)).toBe(fixture)
 })

--- a/packages/remark-custom-blocks/dist/index.js
+++ b/packages/remark-custom-blocks/dist/index.js
@@ -14,24 +14,24 @@ var C_NEWLINE = '\n';
 var C_FENCE = '|';
 
 function compilerFactory(nodeType) {
-  var text = null;
-  var title = null;
+  var text = void 0;
+  var title = void 0;
 
   return {
-    compileTitle: function compileTitle(node) {
+    blockHeading: function blockHeading(node) {
       title = this.all(node).join('');
       return '';
     },
-    compileText: function compileText(node) {
-      text = this.all(node).join('\n').replace(/\n/, '\n| ');
+    blockBody: function blockBody(node) {
+      text = this.all(node).join('\n| ');
       return text;
     },
-    compileFullNode: function compileFullNode(node) {
-      text = null;
-      title = null;
+    block: function block(node) {
+      text = '';
+      title = '';
       this.all(node);
       if (title) {
-        return '[[' + nodeType + '|' + title + ']]\n| ' + text;
+        return '[[' + nodeType + ' | ' + title + ']]\n| ' + text;
       } else {
         return '[[' + nodeType + ']]\n| ' + text;
       }
@@ -120,6 +120,7 @@ module.exports = function blockPlugin() {
         },
         children: this.tokenizeInline(blockTitle, now)
       };
+
       blockChildren.unshift(titleNode);
     }
 
@@ -150,9 +151,9 @@ module.exports = function blockPlugin() {
     if (!visitors) return;
     Object.keys(availableBlocks).forEach(function (key) {
       var compiler = compilerFactory(key);
-      visitors[key + 'CustomBlock'] = compiler.compileFullNode;
-      visitors[key + 'CustomBlockHeading'] = compiler.compileTitle;
-      visitors[key + 'CustomBlockBody'] = compiler.compileText;
+      visitors[key + 'CustomBlock'] = compiler.block;
+      visitors[key + 'CustomBlockHeading'] = compiler.blockHeading;
+      visitors[key + 'CustomBlockBody'] = compiler.blockBody;
     });
   }
   // Inject into interrupt rules

--- a/packages/remark-custom-blocks/src/index.js
+++ b/packages/remark-custom-blocks/src/index.js
@@ -8,24 +8,24 @@ const C_NEWLINE = '\n'
 const C_FENCE = '|'
 
 function compilerFactory (nodeType) {
-  let text = null
-  let title = null
+  let text
+  let title
 
   return {
-    compileTitle: function (node) {
+    blockHeading (node) {
       title = this.all(node).join('')
       return ''
     },
-    compileText: function (node) {
-      text = this.all(node).join('\n').replace(/\n/, '\n| ')
+    blockBody (node) {
+      text = this.all(node).join('\n| ')
       return text
     },
-    compileFullNode: function (node) {
-      text = null
-      title = null
+    block (node) {
+      text = ''
+      title = ''
       this.all(node)
       if (title) {
-        return `[[${nodeType}|${title}]]\n| ${text}`
+        return `[[${nodeType} | ${title}]]\n| ${text}`
       } else {
         return `[[${nodeType}]]\n| ${text}`
       }
@@ -110,6 +110,7 @@ module.exports = function blockPlugin (availableBlocks = {}) {
         },
         children: this.tokenizeInline(blockTitle, now),
       }
+
       blockChildren.unshift(titleNode)
     }
 
@@ -140,9 +141,9 @@ module.exports = function blockPlugin (availableBlocks = {}) {
     if (!visitors) return
     Object.keys(availableBlocks).forEach(key => {
       const compiler = compilerFactory(key)
-      visitors[`${key}CustomBlock`] = compiler.compileFullNode
-      visitors[`${key}CustomBlockHeading`] = compiler.compileTitle
-      visitors[`${key}CustomBlockBody`] = compiler.compileText
+      visitors[`${key}CustomBlock`] = compiler.block
+      visitors[`${key}CustomBlockHeading`] = compiler.blockHeading
+      visitors[`${key}CustomBlockBody`] = compiler.blockBody
     })
   }
   // Inject into interrupt rules


### PR DESCRIPTION
Compiler fails to separate the paragraph following a blockquote.