### PR TITLE
Add failing test case

### DIFF
--- a/packages/remark-custom-blocks/__tests__/index.js
+++ b/packages/remark-custom-blocks/__tests__/index.js
@@ -284,3 +284,20 @@ test('compile multiline block to markdown', () => {
   expect(result.contents).toBe(contents)
   expect(renderToMarkdown(result.contents).contents).toBe(result.contents)
 })
+
+test('compile multiline block to markdown, with multiline paragraph', () => {
+  const fixture = dedent`
+    [[information]]
+    | content
+    |
+    | > blockquote
+    |
+    | a long
+    | multiline
+    | paragraph
+  `
+  let {contents} = renderToMarkdown(fixture)
+  contents = renderToMarkdown(contents).contents
+  contents = renderToMarkdown(contents).contents.trim()
+  expect(contents).toBe(fixture)
+})


### PR DESCRIPTION
Here is another failing test:

```md
[[information]]
| content
|
| > blockquote
|
| a long
| multiline
| paragraph
```

gets compiled to:

```md
[[information]]
| content
|
| > blockquote
|
| a long
| multiline

paragraph
```

(Last line `l` becomes `\n${l}` after each compilation. Compiling several times gives the above result.)